### PR TITLE
Drop the cookies API permission

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,7 +16,6 @@
   "permissions": [
     "<all_urls>",
     "contextualIdentities",
-    "cookies",
     "storage",
     "tabs"
   ],


### PR DESCRIPTION
Can we drop the cookies permission from the extension? I did some minimal testing without the cookies permission and didn't encounter any problems. I don't see it being used. Thanks.