### PR TITLE
Disable ESLint linebreak rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,10 +26,6 @@ module.exports = {
         "after": true
       }
     ],
-    "linebreak-style": [
-      "error",
-      "unix"
-    ],
     "no-console": [
       0
     ],

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
-# Normalize line endings by converting to LF on checkin, in case core.autocrlf is not set
-* text=auto
+*.html text
+*.css text
+*.js text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize line endings by converting to LF on checkin, in case core.autocrlf is not set
+* text=auto


### PR DESCRIPTION
Unnecessary since Git automatically handles CRLF conversion on Windows if set up correctly, in which case the ESLint rule only leads to annoying errors on every line.

Plus it's not like the ESLint rule by itself can prevent CRLFs from being committed, so there's no real loss of functionality either.