### PR TITLE
fix favicon error handler

### DIFF
--- a/src/tab.js
+++ b/src/tab.js
@@ -50,7 +50,7 @@ SideTab.prototype = {
 
     const icon = document.createElement("img");
     icon.className = "tab-icon";
-    icon.addEventListener("error", () => this.resetIcon());
+    icon.addEventListener("error", () => this._resetIcon());
     metaImage.appendChild(icon);
     this._iconView = icon;
 


### PR DESCRIPTION
Related to #10.

However, it is not smooth and not cached. Maybe it should be judged with check scheme? Or, any possible to allow loading from Firefox trunk?