### PR TITLE
Japanese localize

### DIFF
--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -1,0 +1,93 @@
+{
+  "extensionName": {
+    "message": "Tab Center Redux"
+  },
+
+  "extensionDescription": {
+    "message": "Tab Center は、ユーザーのタブの使い方から生じるいくつかの問題 (特に「タブを開きすぎてしまう」状況) を解決し、将来の革新に向けてより自在な UI の基礎を提供しようとする試みです。この Firefox アドオンの初回版では、タブを水平ではなく垂直に配置してみました。これは素晴らしい VerticalTabs アドオンに強く触発され、そのアイデアを借用したものです。"
+  },
+
+  "sidebarTitle": {
+    "message": "タブ",
+    "description": "Label shown in the sidebar selector."
+  },
+
+  "newTabBtnLabel": {
+    "message": "新しいタブ",
+    "description": "Label of the New Tab button in the top menu."
+  },
+
+  "newTabBtnTooltip": {
+    "message": "新しいタブを開きます"
+  },
+
+  "closeTabButtonTooltip": {
+    "message": "タブを閉じます"
+  },
+
+  "allTabsLabel": {
+    "message": "すべてのタブを表示...",
+    "description": "Shown at the bottom of the list of tabs if some tabs are filtered by the current search query."
+  },
+
+  "contextMenuReloadTab": {
+    "message": "タブを再読み込み",
+    "description": "Reload Tab context menu item label."
+  },
+
+  "contextMenuPinTab": {
+    "message": "タブをピン留め",
+    "description": "Pin Tab context menu item label."
+  },
+
+  "contextMenuUnpinTab": {
+    "message": "タブのピン留めを外す",
+    "description": "Unpin Tab context menu item label."
+  },
+
+  "contextMenuMuteTab": {
+    "message": "タブをミュート",
+    "description": "Mute Tab context menu item label."
+  },
+
+  "contextMenuUnmuteTab": {
+    "message": "タブのミュートを解除",
+    "description": "Unmute Tab context menu item label."
+  },
+
+  "contextMenuCloseTab": {
+    "message": "タブを閉じる"
+  },
+
+  "contextMenuMoveTabToNewWindow": {
+    "message": "新しいウィンドウへ移動"
+  },
+
+  "contextMenuReloadAllTabs": {
+    "message": "すべてのタブを再読み込み"
+  },
+
+  "contextMenuCloseTabsUnderneath": {
+    "message": "下のタブをすべて閉じる"
+  },
+
+  "contextMenuCloseOtherTabs": {
+    "message": "他のタブをすべて閉じる"
+  },
+
+  "settingsBtnTooltip": {
+    "message": "設定を変更します"
+  },
+
+  "optionsTitle": {
+    "message": "設定"
+  },
+
+  "optionsAlwaysShrinkTabs": {
+    "message": "常にタブを縮小表示する"
+  },
+
+  "optionsDarkTheme": {
+    "message": "暗いテーマ"
+  }
+}


### PR DESCRIPTION
Fix #89

Note: "extensionDescription" message is copied from [TabCenter/addon.properties at v1.36 ·
bwinton/TabCenter](https://github.com/bwinton/TabCenter/blob/v1.36/locales/ja/addon.properties
"TabCenter/addon.properties at v1.36 · bwinton/TabCenter")
