### PR TITLE
Ensure font sizes are consistent with the rest of the Firefox UI

### DIFF
--- a/src/contextmenu.css
+++ b/src/contextmenu.css
@@ -20,7 +20,7 @@ ul.contextmenu {
 
 .contextmenu > li {
   display: block;
-  font-size: 12px;
+  font: -moz-pull-down-menu;
   padding: 3px 20px 3px 23px;
   -moz-user-select: none;
 }

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,13 +1,15 @@
-body {
-  background-color: hsl(0, 0%, 99%);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  font-size: 1.25rem;
+html {
+  font: message-box;
   color: #333;
 }
 
+body {
+  font-size: 1.25rem;
+}
+
 h1 {
-  font-size: 1.6em;
-  font-weight: 400;
+  font-size: 2rem;
+  font-weight: normal;
   margin: 0;
   padding-bottom: 4px;
   margin-bottom: 4px;

--- a/src/tabcenter.css
+++ b/src/tabcenter.css
@@ -12,10 +12,8 @@ html, body {
 
 body {
     background-color: hsl(var(--tab-background-normal));
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font: message-box;
     color: #000;
-    font-size: 12px;
-    font-weight: 400;
     display: flex;
     flex-direction: column;
 }


### PR DESCRIPTION
Leaving this here so I can test it on Windows and Linux later (on Windows I think the tabs titles should be 12px).