### PR TITLE
Add scroll to switch tabs feature

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -89,5 +89,9 @@
 
   "optionsDarkTheme": {
     "message": "Dark theme"
+  },
+  
+  "optionsScrollThroughTabs": {
+    "message": "Scroll through tabs"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -92,6 +92,6 @@
   },
   
   "optionsScrollThroughTabs": {
-    "message": "Scroll through tabs"
+    "message": "Scroll changes tabs"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -91,7 +91,7 @@
     "message": "Dark theme"
   },
   
-  "optionsScrollThroughTabs": {
-    "message": "Scroll changes tabs"
+  "optionsScrollTabs": {
+    "message": "Scroll to change tabs"
   }
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -11,8 +11,8 @@
         <div><input id="alwaysShrink" type="checkbox" /></div>
         <div><label for="darkTheme" id="darkThemeLabel"></label></div>
         <div><input id="darkTheme" type="checkbox" /></div>
-        <div><label for="scrollThroughTabs" id="scrollThroughTabsLabel"></label></div>
-        <div><input id="scrollThroughTabs" type="checkbox" /></div>
+        <div><label for="scrollTabs" id="scrollTabsLabel"></label></div>
+        <div><input id="scrollTabs" type="checkbox" /></div>
     </div>
     <script src="options.js"></script>
   </body>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -11,6 +11,8 @@
         <div><input id="alwaysShrink" type="checkbox" /></div>
         <div><label for="darkTheme" id="darkThemeLabel"></label></div>
         <div><input id="darkTheme" type="checkbox" /></div>
+		<div><label for="scrollThroughTabs" id="scrollThroughTabsLabel"></label></div>
+		<div><input id="scrollThroughTabs" type="checkbox" /></div>
     </div>
     <script src="options.js"></script>
   </body>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -11,8 +11,8 @@
         <div><input id="alwaysShrink" type="checkbox" /></div>
         <div><label for="darkTheme" id="darkThemeLabel"></label></div>
         <div><input id="darkTheme" type="checkbox" /></div>
-		<div><label for="scrollThroughTabs" id="scrollThroughTabsLabel"></label></div>
-		<div><input id="scrollThroughTabs" type="checkbox" /></div>
+        <div><label for="scrollThroughTabs" id="scrollThroughTabsLabel"></label></div>
+        <div><input id="scrollThroughTabs" type="checkbox" /></div>
     </div>
     <script src="options.js"></script>
   </body>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -4,9 +4,12 @@ document.getElementById("alwaysShrinkLabel").textContent =
   browser.i18n.getMessage("optionsAlwaysShrinkTabs");
 document.getElementById("darkThemeLabel").textContent =
   browser.i18n.getMessage("optionsDarkTheme");
+document.getElementById("scrollThroughTabsLabel").textContent =
+  browser.i18n.getMessage("optionsScrollThroughTabs");
 
 setupCheckboxOption("alwaysShrink", "alwaysShrink");
 setupCheckboxOption("darkTheme", "darkTheme");
+setupCheckboxOption("scrollThroughTabs", "scrollTabs");
 
 function setupCheckboxOption(checkboxId, optionName) {
   const checkbox = document.getElementById(checkboxId);

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -4,12 +4,12 @@ document.getElementById("alwaysShrinkLabel").textContent =
   browser.i18n.getMessage("optionsAlwaysShrinkTabs");
 document.getElementById("darkThemeLabel").textContent =
   browser.i18n.getMessage("optionsDarkTheme");
-document.getElementById("scrollThroughTabsLabel").textContent =
-  browser.i18n.getMessage("optionsScrollThroughTabs");
+document.getElementById("scrollTabsLabel").textContent =
+  browser.i18n.getMessage("optionsScrollTabs");
 
 setupCheckboxOption("alwaysShrink", "alwaysShrink");
 setupCheckboxOption("darkTheme", "darkTheme");
-setupCheckboxOption("scrollThroughTabs", "scrollTabs");
+setupCheckboxOption("scrollTabs", "scrollTabs");
 
 function setupCheckboxOption(checkboxId, optionName) {
   const checkbox = document.getElementById(checkboxId);

--- a/src/tablist.js
+++ b/src/tablist.js
@@ -322,19 +322,19 @@ SideTabList.prototype = {
   async onScroll(e){
 	if (!this.scrollTabs) return;
 	e.preventDefault();
-	// One query is (slightly) better for performance
+	// Gets tabs in window, then derives active tab
 	let tabs = await browser.tabs.query({currentWindow: true});
 	for (let tab of tabs) if (tab.active) var currentTab = tab;
-	// WheelEvent.deltaY only returns -3 or 3, so we can easily take that
-	// and modify the current tab's index, then account for wrap
+	// WheelEvent.deltaY only returns -3 or 3. We take that
+	// and modify the current tab's index, then account for wrap.
 	let newTabIndex = currentTab.index + (e.deltaY / 3);
 	if (newTabIndex >= tabs.length) newTabIndex = 0;
 	if (newTabIndex < 0) newTabIndex = tabs.length - 1;
 	let newTab = tabs[newTabIndex];
-	// I toyed with using internal functions, but just letting them
-	// react to the built-in function seems best.
+	// Changes tab. Internal functions react.
     browser.tabs.update(newTab.id, {active: true});
-	e.stopPropagation();
+	// Unclear if this helps.
+	//e.stopPropagation();
   },
   onSpacerDblClick() {
     browser.tabs.create({});

--- a/src/tablist.js
+++ b/src/tablist.js
@@ -19,11 +19,11 @@ SideTabList.prototype = {
     if (this.alwaysShrink) {
       this.maybeShrinkTabs();
     }
-	
-	this.scrollTabs = (await browser.storage.local.get({
+    
+    this.scrollTabs = (await browser.storage.local.get({
       scrollTabs: false
     })).scrollTabs;
-	
+    
     this.setupListeners();
   },
   setupListeners() {
@@ -70,9 +70,9 @@ SideTabList.prototype = {
     document.addEventListener("dragstart", e => this.onDragStart(e));
     document.addEventListener("dragover", e => this.onDragOver(e));
     document.addEventListener("drop", e => this.onDrop(e));
-	
-	// Scroll to switch tabs
-	document.addEventListener("wheel", e => this.onScroll(e));
+    
+    // Scroll to switch tabs
+    document.addEventListener("wheel", e => this.onScroll(e));
 
     // Pref changes
     browser.storage.onChanged.addListener(changes => {
@@ -80,9 +80,9 @@ SideTabList.prototype = {
         this.alwaysShrink = changes.alwaysShrink.newValue;
         this.maybeShrinkTabs();
       }
-	  if (changes.scrollTabs) {
-		  this.scrollTabs = changes.scrollTabs.newValue;
-	  }
+      if (changes.scrollTabs) {
+          this.scrollTabs = changes.scrollTabs.newValue;
+      }
     });
   },
   onBrowserTabActivated(tabId) {
@@ -320,21 +320,21 @@ SideTabList.prototype = {
     browser.tabs.move(tabId, { index: newPos });
   },
   async onScroll(e){
-	if (!this.scrollTabs) return;
-	e.preventDefault();
-	// Gets tabs in window, then derives active tab
-	let tabs = await browser.tabs.query({currentWindow: true});
-	for (let tab of tabs) if (tab.active) var currentTab = tab;
-	// WheelEvent.deltaY only returns -3 or 3. We take that
-	// and modify the current tab's index, then account for wrap.
-	let newTabIndex = currentTab.index + (e.deltaY / 3);
-	if (newTabIndex >= tabs.length) newTabIndex = 0;
-	if (newTabIndex < 0) newTabIndex = tabs.length - 1;
-	let newTab = tabs[newTabIndex];
-	// Changes tab. Internal functions react.
+    if (!this.scrollTabs) return;
+    e.preventDefault();
+    // Gets tabs in window, then derives active tab
+    let tabs = await browser.tabs.query({currentWindow: true});
+    for (let tab of tabs) if (tab.active) var currentTab = tab;
+    // WheelEvent.deltaY only returns -3 or 3. We take that
+    // and modify the current tab's index, then account for wrap.
+    let newTabIndex = currentTab.index + (e.deltaY / 3);
+    if (newTabIndex >= tabs.length) newTabIndex = 0;
+    if (newTabIndex < 0) newTabIndex = tabs.length - 1;
+    let newTab = tabs[newTabIndex];
+    // Changes tab. Internal functions react.
     browser.tabs.update(newTab.id, {active: true});
-	// Unclear if this helps.
-	//e.stopPropagation();
+    // Unclear if this helps.
+    //e.stopPropagation();
   },
   onSpacerDblClick() {
     browser.tabs.create({});

--- a/src/tablist.js
+++ b/src/tablist.js
@@ -19,11 +19,11 @@ SideTabList.prototype = {
     if (this.alwaysShrink) {
       this.maybeShrinkTabs();
     }
-    
+
     this.scrollTabs = (await browser.storage.local.get({
       scrollTabs: false
     })).scrollTabs;
-    
+
     this.setupListeners();
   },
   setupListeners() {
@@ -70,7 +70,7 @@ SideTabList.prototype = {
     document.addEventListener("dragstart", e => this.onDragStart(e));
     document.addEventListener("dragover", e => this.onDragOver(e));
     document.addEventListener("drop", e => this.onDrop(e));
-    
+
     // Scroll to switch tabs
     document.addEventListener("wheel", e => this.onScroll(e));
 
@@ -81,7 +81,7 @@ SideTabList.prototype = {
         this.maybeShrinkTabs();
       }
       if (changes.scrollTabs) {
-          this.scrollTabs = changes.scrollTabs.newValue;
+        this.scrollTabs = changes.scrollTabs.newValue;
       }
     });
   },
@@ -319,17 +319,28 @@ SideTabList.prototype = {
     Math.max(0, dropTabPos);
     browser.tabs.move(tabId, { index: newPos });
   },
-  async onScroll(e){
-    if (!this.scrollTabs) return;
+  async onScroll(e) {
+    if (!this.scrollTabs) {
+      return;
+    }
     e.preventDefault();
     // Gets tabs in window, then derives active tab
     let tabs = await browser.tabs.query({currentWindow: true});
-    for (let tab of tabs) if (tab.active) var currentTab = tab;
+    let currentTab = null;
+    for (let tab of tabs) {
+      if (tab.active) {
+        currentTab = tab;
+      }
+    }
     // WheelEvent.deltaY only returns -3 or 3. We take that
     // and modify the current tab's index, then account for wrap.
     let newTabIndex = currentTab.index + (e.deltaY / 3);
-    if (newTabIndex >= tabs.length) newTabIndex = 0;
-    if (newTabIndex < 0) newTabIndex = tabs.length - 1;
+    if (newTabIndex >= tabs.length) {
+      newTabIndex = 0;
+    }
+    if (newTabIndex < 0) {
+      newTabIndex = tabs.length - 1;
+    }
     let newTab = tabs[newTabIndex];
     // Changes tab. Internal functions react.
     browser.tabs.update(newTab.id, {active: true});


### PR DESCRIPTION
This adds a new feature (and user setting) that changes the scroll behavior to switch between tabs (if enabled). This acts to replace the legacy addon [Tab-Wheel-Scroll](https://github.com/mthamil/Tab-Wheel-Scroll), which works with Tree Style Tabs. Since we won't be able to listen to mouse events over the tab bar ([1246706](https://bugzilla.mozilla.org/show_bug.cgi?id=1246706)), it will have to be relegated to a sidebar extension anyway, and this seems to be the best by far in terms of looks and features.

A few things to note: 
- I'm not entirely sure how localization works in FOSS projects, but it feels wrong to even temporarily use English or machine translations in non-English languages, so I simply didn't add the options string to any other locale.
- On a low number of tabs it performs well. It becomes laggy when switching with a lot of tabs open, and when scrolling *through* a lot of tabs. Any rapid switching of tabs seems to cause the same amount of lag. But to be clear, it definitely performs well enough, there is just room for improvement.
  - We can fix the rapid switching issue by making it wait until the user stops scrolling before determining which tab to switch to, and to fix the responsiveness issues that would case, we could have the tab styling change (to appear active) while the user scrolls, without actually changing tabs. We can even switch to that behavior if they have a lot of tabs open, and/or if they're scrolling a lot. All of this might require a re-write of some other parts of the extension, which is why I haven't attempted it yet.
  - Performance could be improved (theoretically) with internal tab variables. I didn't look much into these, but we need an ordered array of the tabs and the active tab's index in that array, so if there's something less costly than a `browser.tabs.query` that could provide that we can switch over easily.
  - We can gain a lot of performance by delaying or disabling thumbnail updating when scrolling through tabs. "Always Shrink Tabs" shows this.
- Tab-Wheel-Scroll uses [advanceSelectedTab](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Method/advanceSelectedTab) to find and switch to the next tab. As near as I can tell there is no such thing in WebExtensions, and the [method](https://dxr.mozilla.org/mozilla-central/source/toolkit/content/widgets/tabbox.xml#519) is similarly not reproducible, which is why I ended up doing index modifying.

I haven't contributed much to FOSS so please let me know if there's anything I can do better.