### PR TITLE
Only update thumbnail once the loading is complete

### DIFF
--- a/src/tablist.js
+++ b/src/tablist.js
@@ -91,7 +91,6 @@ SideTabList.prototype = {
       this.setTitle(tab);
     }
     if (changeInfo.hasOwnProperty("url")) {
-      this.updateTabThumbnail(tabId);
       this.setURL(tab);
     }
     if (changeInfo.hasOwnProperty("mutedInfo")) {
@@ -101,7 +100,6 @@ SideTabList.prototype = {
       this.setAudible(tab);
     }
     if (changeInfo.status === "loading") {
-      this.updateTabThumbnail(tabId);
       this.setSpinner(tab);
     }
     if (changeInfo.status === "complete") {


### PR DESCRIPTION
I used this extension for a while now, and I quickly noticed that with the sidebar open, the pages are flushing their style before being finished to load. I don't know if pages are loading actually slower, but it feels like it, and all those FOUC are hurting my eyes.

I digged in, and I found out that calling `browser.tabs.captureVisibleTab` anytime before the `complete` "event" caused this: Firefox probably needs to render the whole page immediately to take a screenshot.

Removing the other two calls to `updateTabThumbnail` does not change the thumbnails behavior excessively, and browsing the Web is much more enjoyable 😄 

Note: I am using Firefox Nightly (up to date) on Arch Linux.