### PR TITLE
Update the tab favicon when it changes

### DIFF
--- a/src/tablist.js
+++ b/src/tablist.js
@@ -90,6 +90,9 @@ SideTabList.prototype = {
     if (changeInfo.hasOwnProperty("title")) {
       this.setTitle(tab);
     }
+    if (changeInfo.hasOwnProperty("favIconUrl")) {
+      this.setIcon(tab);
+    }
     if (changeInfo.hasOwnProperty("url")) {
       this.updateTabThumbnail(tabId);
       this.setURL(tab);


### PR DESCRIPTION
When the page is updating its favicon at runtime (ex: gmail showing the mail count on the favicon), the favicon does not change immediately.

Let's fix this!