### PR TITLE
Add contextual menu to reopen last closed tab

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -59,6 +59,10 @@
     "message": "Close Tab"
   },
 
+  "contextMenuUndoCloseTab": {
+    "message": "Undo Close Tab"
+  },
+
   "contextMenuMoveTabToNewWindow": {
     "message": "Move to New Window"
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -59,6 +59,10 @@
     "message": "Fermer l'onglet"
   },
 
+  "contextMenuUndoCloseTab": {
+    "message": "Annuler la fermeture de l'onglet"
+  },
+
   "contextMenuMoveTabToNewWindow": {
     "message": "Déplacer vers une nouvelle fenêtre"
   },

--- a/src/contextmenu.css
+++ b/src/contextmenu.css
@@ -30,6 +30,11 @@ ul.contextmenu {
   color: white;
 }
 
+.contextmenu > li.disabled {
+  background-color: #dbdbdb;
+  color: grey;
+}
+
 /* DARK THEME CUSTOMIZATIONS */
 body.dark-theme ul.contextmenu {
   border: solid 1px #555;

--- a/src/contextmenu.js
+++ b/src/contextmenu.js
@@ -13,15 +13,28 @@ ContextMenu.prototype = {
     this.rootNode = document.createElement("ul");
     this.rootNode.classList = "contextmenu";
     const fragment = document.createDocumentFragment();
-    for (let { label, onCommandFn } of this.items) {
+    for (let { label, isEnabled, onCommandFn } of this.items) {
       let item;
       if (label == "separator") {
         item = document.createElement("hr");
       } else {
         item = document.createElement("li");
         item.textContent = label;
-        if (onCommandFn) {
-          item.addEventListener("click", e => onCommandFn(e));
+
+        if (isEnabled) {
+          isEnabled().then(result => {
+            if (!result) {
+              item.className = "disabled";
+            } else {
+              if (onCommandFn) {
+                item.addEventListener("click", e => onCommandFn(e));
+              }
+            }
+          });
+        } else {
+          if (onCommandFn) {
+            item.addEventListener("click", e => onCommandFn(e));
+          }
         }
       }
       fragment.appendChild(item);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,6 +17,7 @@
     "<all_urls>",
     "contextualIdentities",
     "cookies",
+    "sessions",
     "storage",
     "tabs"
   ],

--- a/src/tablist.js
+++ b/src/tablist.js
@@ -78,6 +78,7 @@ SideTabList.prototype = {
         this.maybeShrinkTabs();
       }
     });
+
   },
   onBrowserTabActivated(tabId) {
     this.setActive(tabId);
@@ -226,14 +227,35 @@ SideTabList.prototype = {
         browser.tabs.remove(tabId);
       }
     });
+
     items.push({
       label: browser.i18n.getMessage("contextMenuUndoCloseTab"),
+      isEnabled: () => {
+        return new Promise(resolve => {
+          function hasSessions (sessions) {
+            if (sessions.length) {
+              resolve(true);
+            } else {
+              resolve(false);
+            }
+          }
+
+          function onError (error) {
+            console.log(error);
+          }
+
+          browser.sessions.getRecentlyClosed({
+            maxResults: 1
+          }).then(hasSessions, onError);
+        });
+      },
       onCommandFn: () => {
         function restoreMostRecent (sessionInfos) {
           if (!sessionInfos.length) {
             console.log("No sessions found");
             return;
           }
+
           let sessionInfo = sessionInfos[0];
           if (sessionInfo.tab) {
             browser.sessions.restore(sessionInfo.tab.sessionId);

--- a/src/tablist.js
+++ b/src/tablist.js
@@ -226,6 +226,29 @@ SideTabList.prototype = {
         browser.tabs.remove(tabId);
       }
     });
+    items.push({
+      label: browser.i18n.getMessage("contextMenuUndoCloseTab"),
+      onCommandFn: () => {
+        function restoreMostRecent (sessionInfos) {
+          if (!sessionInfos.length) {
+            console.log("No sessions found");
+            return;
+          }
+          let sessionInfo = sessionInfos[0];
+          if (sessionInfo.tab) {
+            browser.sessions.restore(sessionInfo.tab.sessionId);
+          }
+        }
+
+        function onError (error) {
+          console.log(error);
+        }
+
+        browser.sessions.getRecentlyClosed({
+          maxResults: 1
+        }).then(restoreMostRecent, onError);
+      }
+    });
     return items;
   },
   onClick(e) {


### PR DESCRIPTION
Hi,

Simple feature to add as already written in Mozilla documentation.

But, I'm not sure if we should call label it "Undo Close Tab" or "Reopen Tab".

Also, I removed  the part to reopen last window and I'm not sure if we should hide the menu if no tab closed yet.

I didn't dig to much in the addon source code and I'm not sure were to put this kind of logic (check if a tab was already closed and so display the menu)

Didn't translate in all available languages, should I ?

Ref to #147 