### PR TITLE
Firefox Photon Design

### DIFF
--- a/src/contextmenu.css
+++ b/src/contextmenu.css
@@ -38,8 +38,8 @@ ul.contextmenu {
 
 /* DARK THEME CUSTOMIZATIONS */
 body.dark-theme ul.contextmenu {
-  border: solid 1px #555;
-  background-color: #3D414A;
+  border: solid 1px rgba(12, 12, 13, 0.3);
+  background-color: #38383d;
 }
 
 body.dark-theme .contextmenu > hr {

--- a/src/contextmenu.css
+++ b/src/contextmenu.css
@@ -4,6 +4,7 @@ ul.contextmenu {
   border: solid 1px #CCCCCC;
   margin: 0;
   padding: 0;
+  color: black;
   background-color: #f2f2f2;
   box-shadow: 1px 1px 1px #888888;
   z-index: 100;
@@ -34,14 +35,4 @@ ul.contextmenu {
 .contextmenu > li.disabled {
   pointer-events: none;
   color: grey;
-}
-
-/* DARK THEME CUSTOMIZATIONS */
-body.dark-theme ul.contextmenu {
-  border: solid 1px rgba(12, 12, 13, 0.3);
-  background-color: #38383d;
-}
-
-body.dark-theme .contextmenu > hr {
-  background-color: #888;
 }

--- a/src/img/find.svg
+++ b/src/img/find.svg
@@ -8,7 +8,7 @@
       display: none;
     }
     #standard {
-      fill: "#4c4c4c";
+      fill: hsla(240, 4%, 5%, 0.8);
     }
     #inverted {
       fill: hsla(240, 9%, 98%, 0.8);

--- a/src/img/find.svg
+++ b/src/img/find.svg
@@ -1,6 +1,22 @@
+<?xml version="1.0"?>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
-  <path d="M11.354,10.646l-0.707.707L7.295,8A4.483,4.483,0,1,1,9,4.5,4.458,4.458,0,0,1,8,7.295ZM4.5,1A3.5,3.5,0,1,0,8,4.5,3.5,3.5,0,0,0,4.5,1Z" fill="#4c4c4c" transform="translate(4 4)"/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20" height="20" viewBox="0 0 20 20">
+  <style>
+    .icon:not(:target) {
+      display: none;
+    }
+    #standard {
+      fill: "#4c4c4c";
+    }
+    #inverted {
+      fill: hsla(240, 9%, 98%, 0.8);
+    }
+  </style>
+  <defs>
+  	<path id="find" d="M11.354,10.646l-0.707.707L7.295,8A4.483,4.483,0,1,1,9,4.5,4.458,4.458,0,0,1,8,7.295ZM4.5,1A3.5,3.5,0,1,0,8,4.5,3.5,3.5,0,0,0,4.5,1Z" transform="translate(4 4)"/>
+  </defs>
+  <use id="standard" class="icon" xlink:href="#find" />
+  <use id="inverted" class="icon" xlink:href="#find" />
 </svg>

--- a/src/img/glyph-close-16.svg
+++ b/src/img/glyph-close-16.svg
@@ -8,7 +8,7 @@
       display: none;
     }
     #standard {
-      fill: #4c4c4c;
+      fill: hsla(240, 4%, 5%, 0.8);
     }
     #inverted {
       fill: hsla(240, 9%, 98%, 0.8);

--- a/src/img/glyph-close-16.svg
+++ b/src/img/glyph-close-16.svg
@@ -11,7 +11,7 @@
       fill: #4c4c4c;
     }
     #inverted {
-      fill: #E6E6E6;
+      fill: hsla(240, 9%, 98%, 0.8);
     }
   </style>
   <defs>

--- a/src/img/glyph-new-16.svg
+++ b/src/img/glyph-new-16.svg
@@ -8,7 +8,7 @@
       display: none;
     }
     #standard {
-      fill: "#4c4c4c";
+      fill: hsla(240, 4%, 5%, 0.8);
     }
     #inverted {
       fill: hsla(240, 9%, 98%, 0.8);

--- a/src/img/glyph-new-16.svg
+++ b/src/img/glyph-new-16.svg
@@ -4,10 +4,19 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16">
   <style>
-    polygon {
-      fill: #4c4c4c;
+    .icon:not(:target) {
+      display: none;
+    }
+    #standard {
+      fill: "#4c4c4c";
+    }
+    #inverted {
+      fill: hsla(240, 9%, 98%, 0.8);
     }
   </style>
-
-  <polygon points="14,7 9,7 9,2 7,2 7,7 2,7 2,9 7,9 7,14 9,14 9,9 14,9 "/>
+  <defs>
+ 	<polygon id="new" points="14,7 9,7 9,2 7,2 7,7 2,7 2,9 7,9 7,14 9,14 9,9 14,9 "/>
+ </defs>
+ <use id="standard" class="icon" xlink:href="#new" />
+ <use id="inverted" class="icon" xlink:href="#new" />
 </svg>

--- a/src/img/settings.svg
+++ b/src/img/settings.svg
@@ -11,7 +11,7 @@
       fill: "context-fill";
     }
     #inverted {
-      fill: #C0C0C0;
+      fill: hsla(240, 9%, 98%, 0.8);
     }
   </style>
   <defs>

--- a/src/img/settings.svg
+++ b/src/img/settings.svg
@@ -8,7 +8,7 @@
       display: none;
     }
     #standard {
-      fill: "context-fill";
+      fill: hsla(240, 4%, 5%, 0.8);
     }
     #inverted {
       fill: hsla(240, 9%, 98%, 0.8);

--- a/src/tabcenter.css
+++ b/src/tabcenter.css
@@ -1,9 +1,9 @@
 @import url("contextmenu.css");
 
 :root {
-    --tab-background-normal: 220, 6%, 90%, 1;
-    --tab-background-active: 210, 11%, 96%, 1;
-    --tab-background-hover: 240, 4%, 5%, 0.1;
+    --tab-background-normal: 220, 6%, 90%;
+    --tab-background-active: 210, 11%, 96%;
+    --tab-background-hover: 220, 3%, 81%;
     --tab-border-color: rgba(12, 12, 13, .2);
     --searchbox-background: #fff;
     --primary-border-color: rgba(12, 12, 13, .2);
@@ -20,7 +20,7 @@ html, body {
 }
 
 body {
-    background-color: hsla(var(--tab-background-normal));
+    background-color: hsl(var(--tab-background-normal));
     font: message-box;
     color: var(--primary-text-color);
     display: flex;
@@ -34,7 +34,7 @@ body {
 #topmenu {
     display: flex;
     padding: 6px 4px;
-    background-color: hsla(var(--tab-background-active));
+    background-color: hsl(var(--tab-background-active));
 }
 
 #newtab {
@@ -46,10 +46,6 @@ body {
     align-items: center;
     padding: 2px 4px;
     text-shadow: 0 1px rgba(255, 255, 255, .4);
-}
-
-.tab {
-    color: var(--primary-text-color);
 }
 
 /* This is important for event bubbling: when we click a tab, e.target
@@ -77,7 +73,7 @@ img, .tab *:not(.clickable) {
     top: 31px;
     left: 8px;
     flex-direction: column;
-    background-color: hsla(var(--tab-background-active));
+    background-color: hsl(var(--tab-background-active));
     border: 1px solid #C9C9C9;
     box-shadow: 1px 1px 1px #888888;
 }
@@ -282,7 +278,7 @@ img, .tab *:not(.clickable) {
 }
 
 .tab.active {
-    background-color: hsla(var(--tab-background-active));
+    background-color: hsl(var(--tab-background-active));
 }
 
 .tab:not(.active):hover {
@@ -533,7 +529,7 @@ img, .tab *:not(.clickable) {
 #pinnedtablist {
     display: flex;
     flex-wrap: wrap;
-    background-color: hsla(var(--tab-background-active));
+    background-color: hsl(var(--tab-background-active));
 }
 
 #pinnedtablist:empty {
@@ -597,9 +593,9 @@ img, .tab *:not(.clickable) {
 
 /* DARK THEME CUSTOMIZATIONS */
 body.dark-theme {
-    --tab-background-normal: 240, 4%, 5%, 1;
-    --tab-background-active: 240, 4%, 23%, 1;
-    --tab-background-hover: 240, 4%, 23%, 0.7;
+    --tab-background-normal: 240, 4%, 5%;
+    --tab-background-active: 240, 4%, 23%;
+    --tab-background-hover: 240, 5%, 17%;
     --tab-border-color: #38383d;
     --searchbox-background: rgb(71, 71, 73);
     --primary-border-color: rgba(12, 12, 13, 0.3);

--- a/src/tabcenter.css
+++ b/src/tabcenter.css
@@ -1,9 +1,12 @@
 @import url("contextmenu.css");
 
 :root {
-    --tab-background-normal: 0, 0%, 99%;
-    --tab-background-active: 0, 0%, 87%;
-    --tab-background-hover: 0, 0%, 91%;
+    --tab-background-normal: 220, 6%, 90%, 1;
+    --tab-background-active: 210, 11%, 96%, 1;
+    --tab-background-hover: 210, 11%, 96%, 0.7;
+    --search-box-background: #fff;
+    --primary-text-color: #18191a;
+    --secondary-text-color: #737373;
 }
 
 html, body {
@@ -11,9 +14,9 @@ html, body {
 }
 
 body {
-    background-color: hsl(var(--tab-background-normal));
+    background-color: hsla(var(--tab-background-normal));
     font: message-box;
-    color: #000;
+    color: var(--primary-text-color);
     display: flex;
     flex-direction: column;
 }
@@ -25,7 +28,7 @@ body {
 #topmenu {
     display: flex;
     padding: 6px 4px;
-    border-bottom: 1px solid hsla(0, 0%, 0%, 0.2);
+    background-color: hsla(var(--tab-background-active));
 }
 
 #newtab {
@@ -37,6 +40,10 @@ body {
     align-items: center;
     padding: 2px 4px;
     text-shadow: 0 1px rgba(255, 255, 255, .4);
+}
+
+.tab {
+    color: var(--primary-text-color);
 }
 
 /* This is important for event bubbling: when we click a tab, e.target
@@ -64,7 +71,7 @@ img, .tab *:not(.clickable) {
     top: 31px;
     left: 8px;
     flex-direction: column;
-    background-color: #F2F2F2;
+    background-color: hsla(var(--tab-background-active));
     border: 1px solid #C9C9C9;
     box-shadow: 1px 1px 1px #888888;
 }
@@ -203,7 +210,12 @@ img, .tab *:not(.clickable) {
 
 #newtab-icon {
     min-width: 16px;
+    min-height: 16px;
     margin-right: 2px;
+    background-size: 16px 16px;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-image: url("img/glyph-new-16.svg#standard");
 }
 
 #searchbox {
@@ -221,12 +233,26 @@ img, .tab *:not(.clickable) {
     box-shadow: 0 0 0 2px hsla(210, 100%, 60%, 0.45);
 }
 
+ #searchbox-icon {
+    min-width: 20px;
+    background-size: 20px 20px;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-image: url("img/find.svg#standard");
+}
+
 #searchbox-input {
     flex: 1;
     margin-left: 1;
     padding: 0;
     box-shadow: none;
     border: 0;
+}
+
+#searchbox-icon,
+#searchbox-input {
+    background-color: var(--search-box-background);
+    color: var(--primary-text-color);
 }
 
 #settings {
@@ -259,11 +285,11 @@ img, .tab *:not(.clickable) {
 }
 
 .tab.active {
-    background-color: hsl(var(--tab-background-active));
+    background-color: hsla(var(--tab-background-active));
 }
 
 .tab:not(.active):hover {
-    background-color: hsl(var(--tab-background-hover));
+    background-color: hsla(var(--tab-background-hover));
 }
 
 .tab-context:not(.hasContext) {
@@ -422,6 +448,7 @@ img, .tab *:not(.clickable) {
     display: flex;
     min-width: 0;
     flex-direction: column;
+    opacity: 0.7;
 }
 
 #tablist.shrinked .tab-title-wrapper {
@@ -429,7 +456,7 @@ img, .tab *:not(.clickable) {
 }
 
 .tab.discarded .tab-title {
-    color: grey;
+    color: var(--secondary-text-color);
 }
 
 .tab-title, .tab-host {
@@ -438,7 +465,7 @@ img, .tab *:not(.clickable) {
 }
 
 .tab-host {
-    color: rgb(127, 127, 127);
+    color: var(--secondary-text-color);
 }
 
 #tablist.shrinked .tab-host {
@@ -453,12 +480,16 @@ img, .tab *:not(.clickable) {
     bottom: 0;
     right: 0;
     --tab-background: var(--tab-background-normal);
-    background-image: linear-gradient(to right, hsla(var(--tab-background), 0), hsl(var(--tab-background)) 30%);
+    background-image: linear-gradient(to right, hsla(var(--tab-background), 0), hsla(var(--tab-background)) 30%);
     transform: translateX(36px);
 }
 
 .tab.active > .tab-title-wrapper::after {
     --tab-background: var(--tab-background-active);
+}
+
+.tab.active > .tab-title-wrapper {
+    opacity: 1.0;
 }
 
 .tab:not(.active):hover > .tab-title-wrapper::after {
@@ -478,7 +509,7 @@ img, .tab *:not(.clickable) {
     bottom: 0;
     right: 12px;
     margin: auto;
-    background-color: hsla(0, 0%, 0%, 0.1);
+    background-color: rgba(249, 249, 250, 0);
     background-image: url("img/glyph-close-16.svg#standard");
     background-position: center;
     background-repeat: no-repeat;
@@ -492,10 +523,10 @@ img, .tab *:not(.clickable) {
 }
 
 .tab-close:hover {
-    background-color: hsla(0, 0%, 0%, 0.16) !important;
+    background-color: rgba(249, 249, 250, 0.1) !important;
 }
 .tab-close:active {
-    background-color: hsla(0, 0%, 0%, 0.2) !important;
+    background-color: rgba(249, 249, 250, 0.2) !important;
 }
 
 #tablist.shrinked .tab {
@@ -505,7 +536,7 @@ img, .tab *:not(.clickable) {
 #pinnedtablist {
     display: flex;
     flex-wrap: wrap;
-    background-color: hsla(0, 0%, 0%, 0.02);
+    background-color: hsla(var(--tab-background-active));
 }
 
 #pinnedtablist:empty {
@@ -569,14 +600,13 @@ img, .tab *:not(.clickable) {
 
 /* DARK THEME CUSTOMIZATIONS */
 body.dark-theme {
-    --tab-background-normal: 223, 15.2%, 18%;
-    --tab-background-active: 221, 41.4%, 33.1%;
-    --tab-background-hover: 222, 28.3%, 25.55%;
-    color: #c0c0c0;
-}
-
-body.dark-theme .tab {
-  color: #808080;
+    --tab-background-normal: 240, 4%, 5%, 1;
+    --tab-background-active: 240, 4%, 23%, 1;
+    --tab-background-hover: 240, 4%, 23%, 0.7;
+    --search-box-background: rgb(71, 71, 73);
+    --primary-text-color: #fff;
+    --secondary-text-color: #f9f9fa;
+    color: var(--primary-text-color);
 }
 
 body.dark-theme #newtab {
@@ -585,15 +615,11 @@ body.dark-theme #newtab {
 
 body.dark-theme #newtab.menuopened,
 body.dark-theme .topmenu-button:hover {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0, 0%, 45%, 0.8);
 }
 
 body.dark-theme .topmenu-button:active {
-    background-color: rgba(255, 255, 255, 0.2);
-}
-
-body.dark-theme #newtab-menu {
-    background-color: #3D414A;
+    background-color: hsla(0, 0%, 45%, 1);
 }
 
 body.dark-theme .newtab-menu-identity:hover {
@@ -601,29 +627,11 @@ body.dark-theme .newtab-menu-identity:hover {
 }
 
 body.dark-theme #searchbox {
-    border: 1px solid rgb(29, 35, 40);
+    border: 1px solid rgba(12, 12, 13, 0.3);
 }
 
-body.dark-theme #searchbox-icon,
-body.dark-theme #searchbox-input {
-    background-color: rgb(23, 27, 31);
-    color: #111;
-}
-
-body.dark-theme .tab.discarded .tab-title {
-    color: #626262;
-}
-
-body.dark-theme .tab-host {
-    color: #606060;
-}
-
-body.dark-theme .tab:hover .tab-host {
-    color: #808080;
-}
-
-body.dark-theme .tab.active .tab-host {
-    color: #c0c0c0;
+body.dark-theme #searchbox-icon {
+    background-image: url("img/find.svg#inverted");
 }
 
 body.dark-theme .tab-icon-overlay {
@@ -631,7 +639,7 @@ body.dark-theme .tab-icon-overlay {
 }
 
 body.dark-theme #newtab-icon {
-  filter: brightness(200%);
+  background-image: url("img/glyph-new-16.svg#inverted");
 }
 
 body.dark-theme #settings {
@@ -646,19 +654,7 @@ body.dark-theme #tablist.shrinked .tab.loading .tab-icon::before {
     background-image: url("img/loading-spinner.svg#inverted");
 }
 
-body.dark-theme .tab:hover {
-    color: #e6e6e6;
-}
-
-body.dark-theme .tab.active {
-    color: #fff;
-}
-
-body.dark-theme #topmenu {
-  background-color: #393f4c;
-}
-
 body.dark-theme #pinnedtablist {
-  background-color: #2c323f;
+  background-color: hsla(var(--tab-background-active));
 }
 

--- a/src/tabcenter.css
+++ b/src/tabcenter.css
@@ -3,10 +3,16 @@
 :root {
     --tab-background-normal: 220, 6%, 90%, 1;
     --tab-background-active: 210, 11%, 96%, 1;
-    --tab-background-hover: 210, 11%, 96%, 0.7;
-    --search-box-background: #fff;
+    --tab-background-hover: 240, 4%, 5%, 0.1;
+    --tab-border-color: rgba(12, 12, 13, .2);
+    --searchbox-background: #fff;
+    --primary-border-color: rgba(12, 12, 13, .2);
     --primary-text-color: #18191a;
     --secondary-text-color: #737373;
+    --close-button-hover: rgba(41, 41, 46, .1);
+    --close-button-active: rgba(41, 41, 46, .2);
+    --menu-button-hover: rgba(12, 12, 13, .1);
+    --menu-button-active: rgba(12, 12, 13, .2);
 }
 
 html, body {
@@ -93,43 +99,35 @@ img, .tab *:not(.clickable) {
 }
 
 [data-identity-color="blue"] {
-  --identity-tab-color: #0996f8;
-  --identity-icon-color: #00a7e0;
+  --identity-color: #37adff;
 }
 
 [data-identity-color="turquoise"] {
-  --identity-tab-color: #01bdad;
-  --identity-icon-color: #01bdad;
+  --identity-color: #00c79a;
 }
 
 [data-identity-color="green"] {
-  --identity-tab-color: #57bd35;
-  --identity-icon-color:  #7dc14c;
+  --identity-color: #51cd00;
 }
 
 [data-identity-color="yellow"] {
-  --identity-tab-color: #ffcb00;
-  --identity-icon-color: #ffcb00;
+  --identity-color: #ffcb00;
 }
 
 [data-identity-color="orange"] {
-  --identity-tab-color: #ff9216;
-  --identity-icon-color: #ff9216;
+  --identity-color: #ff9f00;
 }
 
 [data-identity-color="red"] {
-  --identity-tab-color: #d92215;
-  --identity-icon-color: #d92215;
+  --identity-color: #ff613d;
 }
 
 [data-identity-color="pink"] {
-  --identity-tab-color: #ea385e;
-  --identity-icon-color: #ee5195;
+  --identity-color: #ff4bda;
 }
 
 [data-identity-color="purple"] {
-  --identity-tab-color: #7a2f7a;
-  --identity-icon-color: #7a2f7a;
+  --identity-color: #af51f5;
 }
 
 [data-identity-icon="fingerprint"] {
@@ -186,7 +184,7 @@ img, .tab *:not(.clickable) {
     height: 16px;
     background-image: var(--identity-icon);
     -moz-context-properties: fill;
-    fill: var(--identity-icon-color);
+    fill: var(--identity-color);
     filter: url("img/filters.svg#fill");
     background-size: contain;
     background-repeat: no-repeat;
@@ -200,12 +198,11 @@ img, .tab *:not(.clickable) {
 
 #newtab.menuopened,
 .topmenu-button:hover {
-    border: 1px solid hsla(0, 0%, 0%, 0.16);
-    background-color: hsla(0, 0%, 0%, 0.1);
+    background-color: var(--menu-button-hover);
 }
 
 .topmenu-button:active {
-    background-color: hsla(0, 0%, 0%, 0.16);
+    background-color: var(--menu-button-active);
 }
 
 #newtab-icon {
@@ -223,14 +220,13 @@ img, .tab *:not(.clickable) {
     margin: 0 4px;
     flex: 20 0 auto;
     min-width: 45px;
-    border: 1px solid rgba(0, 0, 0, 0.16);
+    border: 1px solid var(--primary-border-color);
     border-radius: 2.5px;
     transition: border-color 0.1s, box-shadow 0.1s;
 }
 
 #searchbox.focused {
-    border: 1px solid hsla(210, 100%, 60%, 0.6);
-    box-shadow: 0 0 0 2px hsla(210, 100%, 60%, 0.45);
+    border: 1px solid #0a84ff;
 }
 
  #searchbox-icon {
@@ -251,7 +247,7 @@ img, .tab *:not(.clickable) {
 
 #searchbox-icon,
 #searchbox-input {
-    background-color: var(--search-box-background);
+    background-color: var(--searchbox-background);
     color: var(--primary-text-color);
 }
 
@@ -273,6 +269,7 @@ img, .tab *:not(.clickable) {
 }
 
 #tablist {
+    border-top: 1px solid var(--primary-border-color);
     overflow-x: hidden;
 }
 
@@ -280,7 +277,7 @@ img, .tab *:not(.clickable) {
     display: flex;
     align-items: center;
     height: 56px;
-    border-bottom: 1px solid hsla(0, 0%, 0%, 0.06);
+    border-bottom: 1px solid var(--tab-border-color);
     position: relative;
 }
 
@@ -293,7 +290,7 @@ img, .tab *:not(.clickable) {
 }
 
 .tab-context:not(.hasContext) {
-    --identity-tab-color: #1aa1ff;
+    --identity-color: #0a84ff;
 }
 
 .tab-context {
@@ -301,7 +298,7 @@ img, .tab *:not(.clickable) {
     height: 100%;
     background-image:
         linear-gradient(to right, hsla(0, 0%, 0%, 0.25) 17%, hsla(0, 0%, 0%, 0.1) 17%, transparent 67%),
-        linear-gradient(to right, var(--identity-tab-color), var(--identity-tab-color));
+        linear-gradient(to right, var(--identity-color), var(--identity-color));
     background-position: 0 0;
     background-repeat: no-repeat;
     transition: background-position 150ms ease-out;
@@ -338,7 +335,7 @@ img, .tab *:not(.clickable) {
     margin: 0 0 -13px -13px;
     left: auto;
     top: auto;
-    bottom: 0px;
+    bottom: 0;
     right: -22px;
 }
 
@@ -386,7 +383,7 @@ img, .tab *:not(.clickable) {
 }
 
 #tablist:not(.shrinked) .tab-icon-wrapper {
-    margin-left: 0px;
+    margin-left: 0;
     margin-top: 20px;
     border-radius :2px;
     background-color: white;
@@ -523,10 +520,10 @@ img, .tab *:not(.clickable) {
 }
 
 .tab-close:hover {
-    background-color: rgba(249, 249, 250, 0.1) !important;
+    background-color: var(--close-button-hover) !important;
 }
 .tab-close:active {
-    background-color: rgba(249, 249, 250, 0.2) !important;
+    background-color: var(--close-button-active) !important;
 }
 
 #tablist.shrinked .tab {
@@ -603,39 +600,27 @@ body.dark-theme {
     --tab-background-normal: 240, 4%, 5%, 1;
     --tab-background-active: 240, 4%, 23%, 1;
     --tab-background-hover: 240, 4%, 23%, 0.7;
-    --search-box-background: rgb(71, 71, 73);
+    --tab-border-color: #38383d;
+    --searchbox-background: rgb(71, 71, 73);
+    --primary-border-color: rgba(12, 12, 13, 0.3);
     --primary-text-color: #fff;
     --secondary-text-color: #f9f9fa;
-    color: var(--primary-text-color);
-}
-
-body.dark-theme #newtab {
-    text-shadow: 0 1px rgba(0, 0, 0, .4);
-}
-
-body.dark-theme #newtab.menuopened,
-body.dark-theme .topmenu-button:hover {
-    background-color: hsla(0, 0%, 45%, 0.8);
-}
-
-body.dark-theme .topmenu-button:active {
-    background-color: hsla(0, 0%, 45%, 1);
+    --close-button-hover: rgba(238, 238, 241, .1);
+    --close-button-active: rgba(238, 238, 241, .2);
+    --menu-button-hover: rgba(238, 238, 241, .2);
+    --menu-button-active: rgba(238, 238, 241, .3);
 }
 
 body.dark-theme .newtab-menu-identity:hover {
     background-color: rgb(86, 117, 185);
 }
 
-body.dark-theme #searchbox {
-    border: 1px solid rgba(12, 12, 13, 0.3);
+body.dark-theme .tab-icon-overlay {
+    background-color: #333;
 }
 
 body.dark-theme #searchbox-icon {
     background-image: url("img/find.svg#inverted");
-}
-
-body.dark-theme .tab-icon-overlay {
-    background-color: #333;
 }
 
 body.dark-theme #newtab-icon {
@@ -653,8 +638,3 @@ body.dark-theme .tab-close {
 body.dark-theme #tablist.shrinked .tab.loading .tab-icon::before {
     background-image: url("img/loading-spinner.svg#inverted");
 }
-
-body.dark-theme #pinnedtablist {
-  background-color: hsla(var(--tab-background-active));
-}
-

--- a/src/tabcenter.css
+++ b/src/tabcenter.css
@@ -73,13 +73,15 @@ img, .tab *:not(.clickable) {
     top: 31px;
     left: 8px;
     flex-direction: column;
-    background-color: hsl(var(--tab-background-active));
+    color: black;
+    background-color: #f2f2f2;
     border: 1px solid #C9C9C9;
     box-shadow: 1px 1px 1px #888888;
 }
 
 .newtab-menu-identity:hover {
-    background-color: #D5D5D5;
+    background-color: #3E93F9;
+    color: white;
 }
 
 .newtab-menu-identity {
@@ -539,7 +541,7 @@ img, .tab *:not(.clickable) {
 .tab.pinned > .tab-icon-overlay {
     width: 13px;
     height: 13px;
-    margin: 0 0 -13px 0px;
+    margin: 0 0 -13px 0;
     left: auto;
     top: auto;
     bottom: -12px;
@@ -605,14 +607,6 @@ body.dark-theme {
     --close-button-active: rgba(238, 238, 241, .2);
     --menu-button-hover: rgba(238, 238, 241, .2);
     --menu-button-active: rgba(238, 238, 241, .3);
-}
-
-body.dark-theme .newtab-menu-identity:hover {
-    background-color: rgb(86, 117, 185);
-}
-
-body.dark-theme .tab-icon-overlay {
-    background-color: #333;
 }
 
 body.dark-theme #searchbox-icon {

--- a/src/tabcenter.html
+++ b/src/tabcenter.html
@@ -7,12 +7,12 @@
   <body>
     <div id="topmenu">
       <div id="newtab" class="topmenu-button topmenu-item">
-        <img id="newtab-icon" src="img/glyph-new-16.svg" />
+        <span id="newtab-icon"></span>
         <span id="newtab-label"></span>
       </div>
       <div id="newtab-menu" class="hidden"></div>
       <label id="searchbox" class="topmenu-item">
-        <img src="img/find.svg" id="searchbox-icon" />
+        <span id="searchbox-icon"></span>
         <input type="text" id="searchbox-input" size="1" />
       </label>
       <div id="settings" class="topmenu-button topmenu-item"></div>


### PR DESCRIPTION
Closes #170

This is probably still needs more work, specially the light theme. The light theme is currently following the MacOS Light Theme colors.

The colors listed for the light theme on the Photon Design website don't match the Mac OS light theme at all, I'm not sure what to do about that. Do we follow the listed colors or try and emulate a particular OSes colors?

Submitting now to get some early feedback on the changes included, particularly the CSS restructuring to make the dark and light themes mostly variable changes.