### PR TITLE
Fix undo close tab's window handling

### DIFF
--- a/src/tablist.js
+++ b/src/tablist.js
@@ -263,7 +263,7 @@ SideTabList.prototype = {
       onCommandFn: async () => {
         const undoTabs = await this._getRecentlyClosedTabs();
         if (undoTabs.length) {
-          browser.sessions.restore(undoTabs.sessionId);
+          browser.sessions.restore(undoTabs[0].sessionId);
         }
       }
     });
@@ -276,10 +276,9 @@ SideTabList.prototype = {
     return items;
   },
   async _getRecentlyClosedTabs() {
-    const sessions = await browser.sessions.getRecentlyClosed({
-      maxResults: 1
-    });
-    return sessions.filter(s => s.tab && this.checkWindow(s.tab));
+    const sessions = await browser.sessions.getRecentlyClosed();
+    return sessions.map(s => s.tab)
+                   .filter(s => s && this.checkWindow(s));
   },
   onClick(e) {
     if (SideTab.isCloseButtonEvent(e)) {


### PR DESCRIPTION
Previous commit (0261eca) made the undo option disabled if the latest closed tab was from a different window. This change actually makes it behave like Firefox does.