### PR TITLE
Refactor backgrounds on pinned tabs

### DIFF
--- a/src/tabcenter.css
+++ b/src/tabcenter.css
@@ -2,6 +2,7 @@
 
 :root {
     --tab-background-normal: 0, 0%, 99%;
+    --tab-background-pinned: 0, 0%, 97%;
     --tab-background-active: 0, 0%, 87%;
     --tab-background-hover: 0, 0%, 91%;
     --tab-border-color: hsla(0, 0%, 0%, 0.06);
@@ -622,6 +623,10 @@ body[platform="win"] #searchbox-input:placeholder-shown {
     transform: translateX(36px);
 }
 
+.tab.pinned > .tab-title-wrapper::after {
+    --tab-background: var(--tab-background-pinned);
+}
+
 .tab.active > .tab-title-wrapper::after {
     --tab-background: var(--tab-background-active);
 }
@@ -693,10 +698,13 @@ body[platform="win"] #searchbox-input:placeholder-shown {
     margin-top: 0px;
 }
 
-#pinnedtablist.compact {
+#tablist-wrapper #pinnedtablist {
+    background-color: hsl(var(--tab-background-pinned));
+}
+
+#tablist-wrapper #pinnedtablist.compact {
     display: flex;
     flex-wrap: wrap;
-    background-color: hsla(0, 0%, 0%, 0.02);
 }
 
 #pinnedtablist:empty {
@@ -767,6 +775,7 @@ body[platform="win"] #searchbox-input:placeholder-shown {
 /* DARK THEME CUSTOMIZATIONS */
 body.dark-theme {
     --tab-background-normal: 223, 15.2%, 18%;
+    --tab-background-pinned: 221, 17.75%, 21%;
     --tab-background-active: 221, 41.4%, 33.1%;
     --tab-background-hover: 222, 28.3%, 25.55%;
     --tab-border-color: #38383d;
@@ -820,8 +829,3 @@ body.dark-theme #tablist-wrapper.shrinked .tab.loading .tab-icon::before {
 body.dark-theme #topmenu {
     background-color: #393f4c;
 }
-
-body.dark-theme #pinnedtablist.compact {
-    background-color: #2c323f;
-}
-


### PR DESCRIPTION
Looks like we were working at the same time on the same issue :)
However, I've did it differently - enabled pinned tab colors on both styles and moved the color into the var. Looks cleaner IMO, both visually and in code.