### PR TITLE
Fix search when there are tabs with no title

### DIFF
--- a/src/tablist.js
+++ b/src/tablist.js
@@ -720,7 +720,7 @@ SideTabList.prototype = {
 
 // Remove case and accents/diacritics.
 function normalizeStr(str) {
-  return str.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+  return str ? str.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "") : "";
 }
 
 module.exports = SideTabList;


### PR DESCRIPTION
Noticed on a tab with url: "about:blank" and title: undefined.