### PR TITLE
Remove notselectedsinceload attribute on activating tab.

### DIFF
--- a/src/tab.js
+++ b/src/tab.js
@@ -108,6 +108,7 @@ SideTab.prototype = {
     toggleClass(this.view, "active", active);
     if (active) {
       this._notselectedsinceload = false;
+      this.view.removeAttribute("notselectedsinceload");
     }
   },
   scrollIntoView() {


### PR DESCRIPTION
This way custom CSS can easily use [notselectedsinceload] selector to
style not selected since load tabs.