### PR TITLE
Ensure we always scroll to newly created or moved tab

### DIFF
--- a/src/tablist.js
+++ b/src/tablist.js
@@ -106,7 +106,7 @@ SideTabList.prototype = {
   onBrowserTabActivated(tabId) {
     this.setActive(tabId);
     this.updateTabThumbnail(tabId);
-    this.scrollToActiveTab();
+    this.scrollToTab(tabId);
   },
   onBrowserTabMoved(tabId, moveInfo) {
     this.setPos(tabId, moveInfo.fromIndex < moveInfo.toIndex ?
@@ -464,7 +464,7 @@ SideTabList.prototype = {
     this.view.appendChild(unpinnedFragment);
     this.maybeShrinkTabs();
     this.updateTabThumbnail(this.active);
-    this.scrollToActiveTab();
+    this.scrollToTab(this.active);
   },
   checkWindow(tab) {
     return (tab.windowId == this.windowId);
@@ -552,9 +552,7 @@ SideTabList.prototype = {
     this.setPos(tabInfo.id, tabInfo.index);
 
     this.maybeShrinkTabs();
-    if (tabInfo.active) {
-      this.scrollToActiveTab();
-    }
+    this.scrollToTab(tabInfo.id);
   },
   setActive(tabId) {
     let sidetab = this.getTabById(tabId);
@@ -573,11 +571,8 @@ SideTabList.prototype = {
       sidetab.updateThumbnail(thumbnail);
     }
   },
-  scrollToActiveTab() {
-    if (!this.active) {
-      return;
-    }
-    const sidetab = this.getTabById(this.active);
+  scrollToTab(tabId) {
+    const sidetab = this.getTabById(tabId);
     if (sidetab) {
       sidetab.scrollIntoView();
     }

--- a/src/tablist.js
+++ b/src/tablist.js
@@ -112,6 +112,7 @@ SideTabList.prototype = {
     this.setPos(tabId, moveInfo.fromIndex < moveInfo.toIndex ?
                        moveInfo.toIndex + 1: moveInfo.toIndex
     );
+    this.scrollToTab(tabId);
   },
   onBrowserTabUpdated(tabId, changeInfo, tab) {
     if (!this.checkWindow(tab)) {


### PR DESCRIPTION
- Scroll to a new tab even when opened in background
- Scroll to a tab after it has been moved.

Fix #135 
Fix #242
Maybe fix #209 

I can make it an option if you think it could be annoying to some people.