### PR TITLE
icon: Honour dark/light themes

### DIFF
--- a/src/icons/tabcenter.svg
+++ b/src/icons/tabcenter.svg
@@ -1,13 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="128" width="128" viewBox="0 0 28 28">
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     height="128" width="128" viewBox="0 0 16 16">
   <defs>
     <style>
-      .primary-color {
-        fill: #4d4d4d;
-      }
+      view#dark.theme:target  ~ use#default { fill: #5a5b5c; }
+      view#light.theme:target ~ use#default { fill: #bfbfbf; }
     </style>
+    <symbol id="shape">
+      <path d="M3,1h10a3,3,0,0,1,3,3v8a3,3,0,0,1,-3,3h-10a3,3,0,0,1,-3,-3v-8a3,3,0,0,1,3,-3Z
+               M3,3h 4a1,1,0,0,1,1,1v8a1,1,0,0,1,-1,1h -4a1,1,0,0,1,-1,-1v-8a1,1,0,0,1,1,-1Z"
+            fill-rule="evenodd" />
+      <rect x="3" y="4" height="1" width="4" rx=".5" ry=".5" />
+      <rect x="3" y="6" height="1" width="4" rx=".5" ry=".5" />
+      <rect x="3" y="8" height="1" width="4" rx=".5" ry=".5" />
+    </symbol>
   </defs>
-  <path class="primary-color" d="M12,14H7a1,1,0,0,0,0,2h5a1,1,0,0,0,0-2Z"/>
-  <path class="primary-color" d="M12,10H7a1,1,0,0,0,0,2h5a1,1,0,0,0,0-2Z"/>
-  <path class="primary-color" d="M24,0H4A4,4,0,0,0,0,4V24a4,4,0,0,0,4,4H24a4,4,0,0,0,4-4V4A4,4,0,0,0,24,0ZM16,23a2,2,0,0,1-2,2H5a2,2,0,0,1-2-2V5A2,2,0,0,1,5,3h9a2,2,0,0,1,2,2Z"/>
-  <path class="primary-color" d="M12,6H7A1,1,0,0,0,7,8h5a1,1,0,0,0,0-2Z"/>
+  <view class="theme" id="dark" viewTarget="default" />
+  <view class="theme" id="light" viewTarget="default" />
+  <use  class="theme" id="default" fill="#494e50" href="#shape" />
 </svg>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,8 @@
     "default_icon": "icons/tabcenter.svg"
   },
   "icons": {
-    "48": "icons/tabcenter.svg"
+    "48": "icons/tabcenter.svg",
+    "96": "icons/tabcenter.svg"
   },
   "permissions": [
     "<all_urls>",
@@ -22,8 +23,21 @@
     "tabs"
   ],
   "browser_action": {
-    "default_icon": "icons/tabcenter.svg",
-    "default_title": "__MSG_browserActionTitle__"
+    "browser_style": true,
+    "default_icon": {
+      "16": "icons/tabcenter.svg",
+      "32": "icons/tabcenter.svg"
+    },
+    "default_title": "__MSG_browserActionTitle__",
+    "theme_icons": [{
+      "dark":  "icons/tabcenter.svg#dark",
+      "light": "icons/tabcenter.svg#light",
+      "size": 16
+    }, {
+      "dark":  "icons/tabcenter.svg#dark",
+      "light": "icons/tabcenter.svg#light",
+      "size": 32
+    }]
   },
   "background": {
     "scripts": ["background.js"]


### PR DESCRIPTION
This will probably solve also issue #266.

The icon appearance/definition/usage itself has been slightly changed:

- shape based on <chrome://browser/skin/sidebars.svg>
- shape based on common unit size of 16 instead of 28
- reuse symbol in different default/dark/light themes
- readability – usage of basic shapes, where possible
- consistent theme colours – based on customize panel
- themed icon version accessible via IRI-notation [1]

Specify several icon size and theme definitions in manifest.json [2], so
a correct scaled and themed extension icon can be applied in all places.

References:
  - [1] <https://www.w3.org/TR/SVG11/linking.html#IRIReference>
  - [2] <https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json>