### PR TITLE
Add autofocus to sidebar input, and support navigating filtered results.

### DIFF
--- a/src/tab.js
+++ b/src/tab.js
@@ -239,6 +239,9 @@ Object.assign(SideTab, {
   getAllTabsViews() {
     return document.getElementsByClassName("tab");
   },
+  getVisibleTabViews() {
+    return document.querySelectorAll(".tab:not(.hidden)");
+  },
   _syncThrobberAnimations() {
     requestAnimationFrame(() => {
       if (!document.body.getAnimations) { // this API is available only in Nightly so far

--- a/src/tabcenter.css
+++ b/src/tabcenter.css
@@ -5,6 +5,8 @@
     --tab-background-pinned: 0, 0%, 97%;
     --tab-background-active: 0, 0%, 87%;
     --tab-background-hover: 0, 0%, 91%;
+    --tab-background-selected: 0, 0%, 91%;
+    --tab-background-active-and-selected: 0, 0%, 82%;
     --tab-border-color: hsla(0, 0%, 0%, 0.06);
     --searchbox-background: #fff;
     --primary-text-color: #18191a;
@@ -356,6 +358,14 @@ body[platform="win"] #searchbox-input:placeholder-shown {
     background-color: hsl(var(--tab-background-hover));
 }
 
+.tab.selected {
+    background-color: hsl(var(--tab-background-selected));
+}
+
+.tab.active.selected {
+    background-color: hsl(var(--tab-background-active-and-selected));
+}
+
 /* Tab loading burst is disabled because it triggers on non top-level pages
    (try it on GitHub).
    If you don't mind that, you can re-enable the feature by disabling the
@@ -641,6 +651,14 @@ body[platform="win"] #searchbox-input:placeholder-shown {
 
 .tab:not(.active):hover > .tab-title-wrapper::after {
     --tab-background: var(--tab-background-hover);
+}
+
+.tab.selected > .tab-title-wrapper::after {
+    --tab-background: var(--tab-background-selected);
+}
+
+.tab.active.selected > .tab-title-wrapper::after {
+    --tab-background: var(--tab-background-active-and-selected);
 }
 
 .tab:hover > .tab-title-wrapper::after {

--- a/src/tabcenter.html
+++ b/src/tabcenter.html
@@ -13,7 +13,7 @@
       <div id="newtab-menu" class="hidden"></div>
       <label id="searchbox" class="topmenu-item">
         <span id="searchbox-icon"></span>
-        <input type="text" id="searchbox-input" size="1" />
+        <input type="text" id="searchbox-input" size="1" autofocus="autofocus" />
       </label>
       <div id="settings" class="topmenu-button topmenu-item"></div>
     </div>

--- a/src/tabcenter.js
+++ b/src/tabcenter.js
@@ -28,6 +28,7 @@ TabCenter.prototype = {
     this.setupListeners();
     browser.runtime.getPlatformInfo().then((platform) => {
       document.body.setAttribute("platform", platform.os);
+      this.platform = platform.os;
     });
   },
   setupListeners() {
@@ -50,6 +51,7 @@ TabCenter.prototype = {
     this._searchBoxInput.addEventListener("blur", () => {
       searchbox.classList.remove("focused");
       this._newTabLabelView.classList.remove("hidden");
+      this.sideTabList.clearSelection();
     });
     this._newTabButtonView.addEventListener("click", () => {
       if (!this._newTabMenuShown) {
@@ -89,6 +91,41 @@ TabCenter.prototype = {
         event: "sidebar-closed",
         windowId: this.windowId
       });
+    });
+    this._searchBoxInput.addEventListener("keypress", e => {
+      let delta = 0;
+      switch (e.key) {
+      case "Enter":
+        // Select whatever is already selected. Clear the current search and
+        // selection by default, but allow users to keep them using shift+enter.
+        this.sideTabList.commitSelection(!e.shiftKey);
+        e.preventDefault();
+        break;
+      case "ArrowDown":
+        delta = 1;
+        break;
+      case "ArrowUp":
+        delta = -1;
+        break;
+        // Apple supports emacs-style movement keys (ctrl+{n,p,f,b,a,e}) in
+        // most text boxes/dropdowns/etc. Most users are completely unaware
+        // of it, but I think the relevant items are worth supporting here.
+        // (Think "next line" for Ctrl+N, and "previous line" for Ctrl+P)
+      case "n": case "N":
+        if (e.ctrlKey && this.platform === "mac") {
+          delta = 1;
+        }
+        break;
+      case "p": case "P":
+        if (e.ctrlKey && this.platform === "mac") {
+          delta = -1;
+        }
+        break;
+      }
+      if (delta !== 0) {
+        this.sideTabList.moveSelection(delta);
+        e.preventDefault();
+      }
     });
     browser.storage.onChanged.addListener(changes => {
       if (changes.darkTheme) {

--- a/src/tabcenter.js
+++ b/src/tabcenter.js
@@ -38,10 +38,15 @@ TabCenter.prototype = {
     this._searchBoxInput.addEventListener("input", (e) => {
       this.sideTabList.filter(e.target.value);
     });
-    this._searchBoxInput.addEventListener("focus", () => {
+    const onSearchboxFocus = () => {
       searchbox.classList.add("focused");
       this._newTabLabelView.classList.add("hidden");
-    });
+    };
+    this._searchBoxInput.addEventListener("focus", onSearchboxFocus);
+    // We won't get this message reliably since the item has autofocus.
+    if (document.activeElement === this._searchBoxInput) {
+      onSearchboxFocus();
+    }
     this._searchBoxInput.addEventListener("blur", () => {
       searchbox.classList.remove("focused");
       this._newTabLabelView.classList.remove("hidden");


### PR DESCRIPTION
Most of the sidebars in the browser have focus in the search bar when they come up, so it seems like this one should too. It also helps alleviate #304, which doesn't seem doable currently (`el.focus()` when called from a command handler never seems to work. I can't tell if there's a bug on file for that yet, or if it's even a bug at all vs a design choice).

The second commit is much meatier but basically just adds the notion of a currently "selected" tab to the sidebar. This allows easier navigation of search results with the arrow keys. The behavior I've used was chosen by what "feels" good, and I've added comments to explain the non-obvious parts.

Some notes, most of which are also in comments:

- On mac ctrl+n and ctrl+p are usable as arrow key substitutes. This works in most places on macs (for whatever reason it inherited them from emacs), and I use them constantly, so I've supported them. We ignore them on other platforms, of course.
- Hitting enter in the searchbox opens the selected tab and clears the search, hitting shift+enter opens the selected tab and keeps the search.
- Most manipulations of the tab list clear the selection. This is just because there's no reason to keep it around for long, not a technical limitation.
- We won't use pinned tabs as the initially selected element, but you can still select them.
- If you use arrow keys (or ctrl n/p) when the search panel has focus but is empty, we let you navigate through the tabs same as if you had a search panel.