### PR TITLE
Add a drop shadow after pinned tabs if not scrolled to top.

### DIFF
--- a/src/tabcenter.css
+++ b/src/tabcenter.css
@@ -348,6 +348,14 @@ body[platform="win"] #searchbox-input:placeholder-shown {
     position: relative;
 }
 
+#pinnedtablist.compact:not(:empty) {
+    border-bottom: 1px solid var(--tab-border-color);
+}
+
+#tablist.scrolled-to-start {
+    box-shadow: inset 0px 10px 10px -10px rgba(0, 0, 0, 0.3);
+}
+
 .tab.active {
     background-color: hsl(var(--tab-background-active));
 }

--- a/src/tablist.js
+++ b/src/tablist.js
@@ -25,6 +25,14 @@ SideTabList.prototype = {
   async init() {
     this.setupListeners();
     await this.readPrefs();
+    this.checkScroll();
+  },
+  checkScroll() {
+    if (this.view.scrollTop === 0) {
+      this.view.classList.remove("scrolled-to-start");
+    } else {
+      this.view.classList.add("scrolled-to-start");
+    }
   },
   setupListeners() {
     this._spacerView = document.getElementById("spacer");
@@ -52,6 +60,10 @@ SideTabList.prototype = {
     this.view.addEventListener("mousedown", e => this.onMouseDown(e));
     this.view.addEventListener("contextmenu", e => this.onContextMenu(e));
     this.view.addEventListener("animationend", e => this.onAnimationEnd(e));
+    this.view.addEventListener("scroll", e => {
+      console.log("scrollll", e, this.view.scrollTop, this);
+      this.checkScroll();
+    });
     this.pinnedview.addEventListener("click", e => this.onClick(e));
     this.pinnedview.addEventListener("auxclick", e => this.onAuxClick(e));
     this.pinnedview.addEventListener("mousedown", e => this.onMouseDown(e));


### PR DESCRIPTION
Also, fixes that there's no visible border between pinned and normal
tabs in compact mode (in general, but especially when scrolled to top).

Fixes #240