### PR TITLE
Show attention indicator on pinned tabs that change their title when not active.

### DIFF
--- a/src/img/tab-attention.svg
+++ b/src/img/tab-attention.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
+  <circle r="6" cy="6" cx="6" fill-opacity=".2" fill="#00C8D7" />
+  <circle r="4" cy="6" cx="6" fill-opacity=".6" fill="#00C8D7"  />
+  <circle r="2" cy="6" cx="6" fill="#00FEFF" />
+</svg>

--- a/src/tab.js
+++ b/src/tab.js
@@ -95,6 +95,11 @@ SideTab.prototype = {
     tab.appendChild(close);
   },
   updateTitle(title) {
+    if (this.title && this.title !== title) {
+      if (!this.view.classList.contains("active")) {
+        this.view.classList.add("wants-attention");
+      }
+    }
     this.title = title;
     this._titleView.innerText = title;
     this.view.title = title;
@@ -109,6 +114,7 @@ SideTab.prototype = {
     if (active) {
       this._notselectedsinceload = false;
       this.view.removeAttribute("notselectedsinceload");
+      this.view.classList.remove("wants-attention");
     }
   },
   scrollIntoView() {

--- a/src/tabcenter.css
+++ b/src/tabcenter.css
@@ -762,6 +762,19 @@ body[platform="win"] #searchbox-input:placeholder-shown {
     display: none;
 }
 
+#pinnedtablist .tab.pinned.wants-attention {
+    background-image: url("img/tab-attention.svg");
+    background-repeat: no-repeat;
+}
+
+#pinnedtablist.compact .tab.pinned.wants-attention {
+    background-position: center bottom;
+}
+
+#pinnedtablist:not(.compact) .tab.pinned.wants-attention {
+    background-position: left center;
+}
+
 #moretabs:not([hasMoreTabs]) {
     display: none;
 }


### PR DESCRIPTION
See title. Fixes #268. Doesn't correct #283, since they seem different but if you want you can try and convince me they should really be done together.

Note that the tab-attention.svg is the same as the one we use in firefox (https://searchfox.org/mozilla-central/source/browser/themes/shared/tabbrowser/indicator-tab-attention.svg). I don't know if there are licensing issues with this (I think it should be fine?), but if there are it should be easy to use something else.