### PR TITLE
Display our own favicon for about:addons to work around a Firefox bug

### DIFF
--- a/src/sidebar/img/extensions.svg
+++ b/src/sidebar/img/extensions.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="context-fill" d="M14.5 8c-.971 0-1 1-1.75 1a.765.765 0 0 1-.75-.75V5a1 1 0 0 0-1-1H7.75A.765.765 0 0 1 7 3.25c0-.75 1-.779 1-1.75C8 .635 7.1 0 6 0S4 .635 4 1.5c0 .971 1 1 1 1.75a.765.765 0 0 1-.75.75H1a1 1 0 0 0-1 1v2.25A.765.765 0 0 0 .75 8c.75 0 .779-1 1.75-1C3.365 7 4 7.9 4 9s-.635 2-1.5 2c-.971 0-1-1-1.75-1a.765.765 0 0 0-.75.75V15a1 1 0 0 0 1 1h3.25a.765.765 0 0 0 .75-.75c0-.75-1-.779-1-1.75 0-.865.9-1.5 2-1.5s2 .635 2 1.5c0 .971-1 1-1 1.75a.765.765 0 0 0 .75.75H11a1 1 0 0 0 1-1v-3.25a.765.765 0 0 1 .75-.75c.75 0 .779 1 1.75 1 .865 0 1.5-.9 1.5-2s-.635-2-1.5-2z"></path>
+</svg>

--- a/src/sidebar/tab.js
+++ b/src/sidebar/tab.js
@@ -165,6 +165,10 @@ SideTab.prototype = {
     toggleClass(this.view, "hidden", !show);
   },
   _setIcon(favIconUrl) {
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1462948
+    if (favIconUrl === "chrome://mozapps/skin/extensions/extensionGeneric-16.svg") {
+      favIconUrl = "img/extensions.svg";
+    }
     this._iconView.style.backgroundImage = `url("${favIconUrl}")`;
     const imgTest = document.createElement("img");
     imgTest.src = favIconUrl;


### PR DESCRIPTION
fix #10 