### PR TITLE
Add an option to show hidden tab

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -142,5 +142,9 @@
 
   "optionsSaveCustomCSS": {
     "message": "Save CSS"
+  },
+
+  "optionsShowHidden": {
+    "message": "Show hidden tabs"
   }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -109,5 +109,8 @@
   },
   "optionsSaveCustomCSS": {
     "message": "Enregistrer la CSS"
+  },
+  "optionsShowHidden": {
+    "message": "Afficher les onglets cachés"
   }
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -21,6 +21,8 @@
         </div>
         <div><label for="compactPins" id="optionsCompactPins"></label></div>
         <div><input id="compactPins" type="checkbox" /></div>
+        <div><label for="showHidden" id="optionsShowHidden"></label></div>
+        <div><input id="showHidden" type="checkbox" /></div>
     </div>
     <h1 id="optionsAdvancedTitle"></h1>
     <div class="options">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -9,7 +9,7 @@ TabCenterOptions.prototype = {
       "optionsCompactModeStrict", "optionsCompactModeDynamic",
       "optionsCompactModeOff", "optionsCompactPins", "optionsDarkTheme",
       "optionsThemeIntegration", "optionsAdvancedTitle", "optionsCustomCSS",
-      "optionsCustomCSSWikiLink", "optionsSaveCustomCSS"];
+      "optionsCustomCSSWikiLink", "optionsSaveCustomCSS", "optionsShowHidden"];
     for (let opt of options) {
       this._setupTextContentLabel(opt);
     }
@@ -26,6 +26,7 @@ TabCenterOptions.prototype = {
     this._setupCheckboxOption("themeIntegration", "themeIntegration");
     this._setupDropdownOption("compactMode", "compactModeMode");
     this._setupCheckboxOption("compactPins", "compactPins", true);
+    this._setupCheckboxOption("showHidden", "showHidden");
 
     // Custom CSS
     browser.storage.local.get({

--- a/src/sidebar/tabcenter.js
+++ b/src/sidebar/tabcenter.js
@@ -95,6 +95,7 @@ TabCenter.prototype = {
       compactModeMode: 1/* COMPACT_MODE_DYNAMIC */,
       compactPins: true,
       themeIntegration: false,
+      showHidden: false,
     });
   },
   _applyPrefs(prefs) {


### PR DESCRIPTION
Showing all tabs including the hidden ones can be very handy when mixing with Conex.
Top tabs only show your current container. Side tabs shows everything.

Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>