### PR TITLE
Fix RTL tab titles alignment

### DIFF
--- a/src/sidebar/tabcenter.css
+++ b/src/sidebar/tabcenter.css
@@ -658,6 +658,10 @@ body[platform="win"] #searchbox-input:placeholder-shown {
     margin-left: 6px;
 }
 
+#tablist-wrapper .tab-title-wrapper :dir(rtl) {
+    margin-right: 6px;
+}
+
 .tab.discarded .tab-title {
     opacity: 0.5;
 }
@@ -679,8 +683,12 @@ body[platform="win"] #searchbox-input:placeholder-shown {
     display: none;
 }
 
-.tab-title-wrapper {
+.tab-title-wrapper :dir(ltr){
     mask-image: linear-gradient(to left, transparent 0, black 2em);
+}
+
+.tab-title-wrapper :dir(rtl){
+    mask-image: linear-gradient(to right, transparent 0, black 2em);
 }
 
 .tab:hover:not(.pinned) > .tab-title-wrapper {

--- a/src/sidebar/tabcenter.html
+++ b/src/sidebar/tabcenter.html
@@ -39,7 +39,7 @@
         </div>
       </div>
       <div class="tab-title-wrapper">
-        <div class="tab-title"></div>
+        <div dir="auto" class="tab-title"></div>
         <div class="tab-host"></div>
       </div>
       <div class="tab-pin"></div>


### PR DESCRIPTION
Hi, I'd like to propose a fix for #313. It applies to tab titles only, I've left the tab host names left-aligned.

![image](https://user-images.githubusercontent.com/38829920/66709220-123ad680-ed60-11e9-9690-38dbe769eec7.png)
![image](https://user-images.githubusercontent.com/38829920/66709243-6a71d880-ed60-11e9-89a4-55c82f5e2f0e.png)

Fixes #313
